### PR TITLE
Make Rustler an optional dependency

### DIFF
--- a/PRECOMPILATION_GUIDE.md
+++ b/PRECOMPILATION_GUIDE.md
@@ -123,7 +123,7 @@ time only.
 Optionally it's possible to force the compilation by setting an env var, like the example suggests.
 It's also possible to force the build by using a pre release version, like `0.1.0-dev`. The only
 requirement to force the build is to have Rustler declared as a dependency as well:
-`{:rustler, ">= 0.0.0"}`. In case you are only compiling in dev/test environments, you can specify
+`{:rustler, ">= 0.0.0", optional: true}`. In case you are only compiling in dev/test environments, you can specify
 that with `:only`: `{:rustler, ">= 0.0.0", only: [:dev, :test]}`.
 
 ## The release flow

--- a/PRECOMPILATION_GUIDE.md
+++ b/PRECOMPILATION_GUIDE.md
@@ -123,8 +123,7 @@ time only.
 Optionally it's possible to force the compilation by setting an env var, like the example suggests.
 It's also possible to force the build by using a pre release version, like `0.1.0-dev`. The only
 requirement to force the build is to have Rustler declared as a dependency as well:
-`{:rustler, ">= 0.0.0", optional: true}`. In case you are only compiling in dev/test environments, you can specify
-that with `:only`: `{:rustler, ">= 0.0.0", only: [:dev, :test]}`.
+`{:rustler, ">= 0.0.0", optional: true}`.
 
 ## The release flow
 

--- a/PRECOMPILATION_GUIDE.md
+++ b/PRECOMPILATION_GUIDE.md
@@ -121,7 +121,10 @@ RustlerPrecompiled will try to figure out the target and download the correct fi
 time only.
 
 Optionally it's possible to force the compilation by setting an env var, like the example suggests.
-It's also possible to force the build by using a pre release version, like `0.1.0-dev`.
+It's also possible to force the build by using a pre release version, like `0.1.0-dev`. The only
+requirement to force the build is to have Rustler declared as a dependency as well:
+`{:rustler, ">= 0.0.0"}`. In case you are only compiling in dev/test environments, you can specify
+that with `:only`: `{:rustler, ">= 0.0.0", only: [:dev, :test]}`.
 
 ## The release flow
 

--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -38,7 +38,7 @@ defmodule RustlerPrecompiled do
       It is important to add the ":rustler" package to your dependencies in order to force
       the build. To do that, just add it to your `mix.exs` file:
 
-          {:rustler, ">= 0.0.0"}
+          {:rustler, ">= 0.0.0", optional: true}
 
   In case "force build" is used, all options except `:base_url`, `:version` and `:force_build`
   are going to be passed down to `Rustler`.
@@ -63,7 +63,7 @@ defmodule RustlerPrecompiled do
             use Rustler, only_rustler_opts
           else
             raise "Rustler dependency is needed to force the build. " <>
-                    "Add it to your `mix.exs` file: `{:rustler, \">= 0.0.0\"}`"
+                    "Add it to your `mix.exs` file: `{:rustler, \">= 0.0.0\", optional: true}`"
           end
 
         {:ok, config} ->
@@ -114,7 +114,7 @@ defmodule RustlerPrecompiled do
 
         In order to force the build, you also need to add Rustler as a dependency in your `mix.exs`:
 
-            {:rustler, ">= 0.0.0"}
+            {:rustler, ">= 0.0.0", optional: true}
         """
 
         {:error, message}

--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -35,6 +35,11 @@ defmodule RustlerPrecompiled do
 
           config :rustler_precompiled, :force_build, your_otp_app: true  
 
+      It is important to add the ":rustler" package to your dependencies in order to force
+      the build. To do that, just add it to your `mix.exs` file:
+
+          {:rustler, ">= 0.0.0"}
+
   In case "force build" is used, all options except `:base_url`, `:version` and `:force_build`
   are going to be passed down to `Rustler`.
   So if you need to configure the build, check the `Rustler` options.
@@ -54,7 +59,12 @@ defmodule RustlerPrecompiled do
 
       case RustlerPrecompiled.__using__(__MODULE__, opts) do
         {:force_build, only_rustler_opts} ->
-          use Rustler, only_rustler_opts
+          if Code.ensure_loaded?(Rustler) do
+            use Rustler, only_rustler_opts
+          else
+            raise "Rustler dependency is needed to force the build. " <>
+                    "Add it to your `mix.exs` file: `{:rustler, \">= 0.0.0\"}`"
+          end
 
         {:ok, config} ->
           @on_load :load_rustler_precompiled
@@ -101,6 +111,10 @@ defmodule RustlerPrecompiled do
         You can force the project to build from scratch with:
 
             config :rustler_precompiled, :force_build, #{config.otp_app}: true
+
+        In order to force the build, you also need to add Rustler as a dependency in your `mix.exs`:
+
+            {:rustler, ">= 0.0.0"}
         """
 
         {:error, message}

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule RustlerPrecompiled.MixProject do
 
   defp deps do
     [
-      {:rustler, "~> 0.23"},
+      {:rustler, "~> 0.23", optional: true},
       {:castore, "~> 0.1"},
       {:ex_doc, "~> 0.27", only: :dev},
       {:bypass, "~> 2.1", only: :test}


### PR DESCRIPTION
Users only need Rustler when forcing the build.

Closes https://github.com/philss/rustler_precompiled/issues/11

![Screenshot from 2022-04-28 11-36-15](https://user-images.githubusercontent.com/381213/165777396-55298945-528d-4f57-8c1f-68513315ed0b.png)

