### PR TITLE
Fix usage of Rustler inside __using__ macro

### DIFF
--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -60,11 +60,13 @@ defmodule RustlerPrecompiled do
     quote do
       require Logger
 
-      otp_app = Keyword.fetch!(unquote(opts), :otp_app)
+      opts = unquote(opts)
+
+      otp_app = Keyword.fetch!(opts, :otp_app)
 
       opts =
         Keyword.put_new(
-          unquote(opts),
+          opts,
           :force_build,
           Application.compile_env(:rustler_precompiled, [:force_build, otp_app])
         )


### PR DESCRIPTION
This fix makes possible to compile the module without Rustler available.
The problem before this was because the macro was expanding the "use".