### PR TITLE
Fix `mix rustler_precompiled.download`

### DIFF
--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -164,7 +164,9 @@ defmodule RustlerPrecompiled do
 
     case metadata do
       %{targets: targets, base_url: base_url, basename: basename, version: version} ->
-        for target <- targets do
+        for target_triple <- targets, nif_version <- @available_nif_versions do
+          target = "nif-#{nif_version}-#{target_triple}"
+
           # We need to build again the name because each arch is different.
           lib_name = "#{lib_prefix(target)}#{basename}-v#{version}-#{target}"
 


### PR DESCRIPTION
I made a mistake in #17 and removed `available_targets/0`:

https://github.com/philss/rustler_precompiled/blob/bb146da433b05d7192db732a0c9b10dc6d634074/lib/rustler_precompiled.ex#L156-L163

This causes `mix rustler_precompiled.download YourRustlerModule --all --print` to fail as it tries to download e.g. `libyour_rust_module_nif-v0.1.0-x86_64-unknown-linux-musl.so.tar.gz` without the NIF version.

Ideally we'd also have a test for it. I'll look into it but the cached metadata file makes it a bit tricky.