### PR TITLE
Be more specific about which paths to add from the native folder in the precompilation guide

### DIFF
--- a/PRECOMPILATION_GUIDE.md
+++ b/PRECOMPILATION_GUIDE.md
@@ -159,7 +159,9 @@ defp package do
   [
     files: [
       "lib",
-      "native",
+      "native/example/.cargo",
+      "native/example/src",
+      "native/example/Cargo*",
       "checksum-*.exs",
       "mix.exs"
     ],


### PR DESCRIPTION
The precompilation guide gives an example about paths to include in the `mix.exs` package section prior publishing on hex.pm.
However, the `native` path could contain directories such as `target` which are not needed in the hex.pm package.
This PR makes the example more specific by only adding `.cargo`, `src` and `Cargo.*` paths.