### PR TITLE
Support the `redhat` Linux variant

### DIFF
--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -381,7 +381,7 @@ defmodule RustlerPrecompiled do
 
       target_system.os =~ "linux" ->
         arch = with "amd64" <- target_system.arch, do: "x86_64"
-        vendor = with "pc" <- target_system.vendor, do: "unknown"
+        vendor = with vendor when vendor in ~w(pc redhat) <- target_system.vendor, do: "unknown"
 
         %{target_system | arch: arch, vendor: vendor}
 

--- a/test/rustler_precompiled_test.exs
+++ b/test/rustler_precompiled_test.exs
@@ -28,6 +28,17 @@ defmodule RustlerPrecompiledTest do
     assert {:ok, "nif-2.15-x86_64-apple-darwin"} =
              RustlerPrecompiled.target(config, @available_targets)
 
+    target_system = %{arch: "x86_64", vendor: "redhat", os: "linux", abi: "gnu"}
+
+    config = %{
+      target_system: target_system,
+      nif_version: "2.14",
+      os_type: {:unix, :linux}
+    }
+
+    assert {:ok, "nif-2.14-x86_64-unknown-linux-gnu"} =
+             RustlerPrecompiled.target(config, @available_targets)
+
     target_system = %{arch: "amd64", vendor: "pc", os: "linux", abi: "gnu"}
 
     config = %{


### PR DESCRIPTION
This commit adds support for the `redhat` Linux variant. This means targets such as:

- x86_64-redhat-linux-gnu
- amd64-redhat-linux-gnu

will be treated as `x86_64-unknown-linux-gnu`.

Closes #30.