### PR TITLE
Add `aarch64-unknown-linux-musl` as a default target

### DIFF
--- a/lib/rustler_precompiled/config.ex
+++ b/lib/rustler_precompiled/config.ex
@@ -19,6 +19,7 @@ defmodule RustlerPrecompiled.Config do
 
   @default_targets ~w(
     aarch64-apple-darwin
+    aarch64-unknown-linux-musl
     x86_64-apple-darwin
     x86_64-unknown-linux-gnu
     x86_64-unknown-linux-musl
@@ -110,7 +111,5 @@ defmodule RustlerPrecompiled.Config do
     raise "`#{inspect(field)}` is required for `RustlerPrecompiled`"
   end
 
-  defp pre_release?(version) do
-    "dev" in Version.parse!(version).pre
-  end
+  defp pre_release?(version), do: "dev" in Version.parse!(version).pre
 end

--- a/test/rustler_precompiled/config_test.exs
+++ b/test/rustler_precompiled/config_test.exs
@@ -96,6 +96,7 @@ defmodule RustlerPrecompiled.ConfigTest do
 
     assert config.targets == [
              "aarch64-apple-darwin",
+             "aarch64-unknown-linux-musl",
              "x86_64-apple-darwin",
              "x86_64-unknown-linux-gnu",
              "x86_64-unknown-linux-musl",

--- a/test/rustler_precompiled_test.exs
+++ b/test/rustler_precompiled_test.exs
@@ -185,7 +185,20 @@ defmodule RustlerPrecompiledTest do
       }
 
       error_message =
-        "precompiled NIF is not available for this target: \"i686-unknown-linux-gnu\".\nThe available targets are:\n - aarch64-apple-darwin\n - x86_64-apple-darwin\n - x86_64-unknown-linux-gnu\n - x86_64-unknown-linux-musl\n - arm-unknown-linux-gnueabihf\n - aarch64-unknown-linux-gnu\n - x86_64-pc-windows-msvc\n - x86_64-pc-windows-gnu"
+        """
+        precompiled NIF is not available for this target: \"i686-unknown-linux-gnu\".
+        The available targets are:
+         - aarch64-apple-darwin
+         - aarch64-unknown-linux-musl
+         - x86_64-apple-darwin
+         - x86_64-unknown-linux-gnu
+         - x86_64-unknown-linux-musl
+         - arm-unknown-linux-gnueabihf
+         - aarch64-unknown-linux-gnu
+         - x86_64-pc-windows-msvc
+         - x86_64-pc-windows-gnu
+        """
+        |> String.trim()
 
       assert {:error, ^error_message} = RustlerPrecompiled.target(config, @available_targets)
     end


### PR DESCRIPTION
People using Alpine Linux containers on Apple machines with M1/M2 processors should benefit from this.

Closes #35