### PR TITLE
Fix "force build" with unavailable target

### DIFF
--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -415,9 +415,10 @@ defmodule RustlerPrecompiled do
   # returns only the basic metadata.
   @doc false
   def build_metadata(%Config{} = config) do
-    base_metadata = %{
-      otp_app: config.otp_app,
+    basic_metadata = %{
+      base_url: config.base_url,
       crate: config.crate,
+      otp_app: config.otp_app,
       targets: config.targets,
       version: config.version
     }
@@ -433,12 +434,9 @@ defmodule RustlerPrecompiled do
         cache_dir = cache_dir(config.base_cache_dir, "precompiled_nifs")
         cached_tar_gz = Path.join(cache_dir, "#{file_name}.tar.gz")
 
-        base_url = config.base_url
-
         {:ok,
-         Map.merge(base_metadata, %{
+         Map.merge(basic_metadata, %{
            cached_tar_gz: cached_tar_gz,
-           base_url: base_url,
            basename: basename,
            lib_name: lib_name,
            file_name: file_name,
@@ -447,7 +445,7 @@ defmodule RustlerPrecompiled do
 
       {:error, _} = error ->
         if config.force_build? do
-          {:ok, base_metadata}
+          {:ok, basic_metadata}
         else
           error
         end

--- a/test/rustler_precompiled_test.exs
+++ b/test/rustler_precompiled_test.exs
@@ -414,6 +414,26 @@ defmodule RustlerPrecompiledTest do
       assert error =~ "precompiled NIF is not available for this target: "
       assert error =~ ".\nThe available targets are:\n - hexagon-unknown-linux-musl"
     end
+
+    test "returns a base metadata when target is not available but force build is enabled" do
+      config = %RustlerPrecompiled.Config{
+        otp_app: :rustler_precompiled,
+        module: RustlerPrecompilationExample.Native,
+        base_url:
+          "https://github.com/philss/rustler_precompilation_example/releases/download/v0.2.0",
+        version: "0.2.0",
+        crate: "example",
+        targets: ["hexagon-unknown-linux-musl"],
+        force_build?: true
+      }
+
+      assert {:ok, base_metadata} = RustlerPrecompiled.build_metadata(config)
+
+      assert base_metadata[:otp_app] == :rustler_precompiled
+      assert base_metadata[:crate] == "example"
+      assert base_metadata[:targets] == ["hexagon-unknown-linux-musl"]
+      assert base_metadata[:version] == "0.2.0"
+    end
   end
 
   def in_tmp(tmp_path, function) do

--- a/test/rustler_precompiled_test.exs
+++ b/test/rustler_precompiled_test.exs
@@ -433,6 +433,7 @@ defmodule RustlerPrecompiledTest do
       assert base_metadata[:crate] == "example"
       assert base_metadata[:targets] == ["hexagon-unknown-linux-musl"]
       assert base_metadata[:version] == "0.2.0"
+      assert base_metadata[:base_url] == config.base_url
     end
   end
 


### PR DESCRIPTION
This is going to enable the process of building the metadata even if the current target is not available, but "force_build" is true.

Closes https://github.com/philss/rustler_precompiled/issues/38