### PR TITLE
Add support for suse linux target

### DIFF
--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -391,7 +391,9 @@ defmodule RustlerPrecompiled do
 
       target_system.os =~ "linux" ->
         arch = with "amd64" <- target_system.arch, do: "x86_64"
-        vendor = with vendor when vendor in ~w(pc redhat) <- target_system.vendor, do: "unknown"
+
+        vendor =
+          with vendor when vendor in ~w(pc redhat suse) <- target_system.vendor, do: "unknown"
 
         %{target_system | arch: arch, vendor: vendor}
 

--- a/test/rustler_precompiled_test.exs
+++ b/test/rustler_precompiled_test.exs
@@ -45,6 +45,19 @@ defmodule RustlerPrecompiledTest do
                RustlerPrecompiled.target(config, @available_targets)
     end
 
+    test "x86_64 in a PC running SUSE Linux" do
+      target_system = %{arch: "x86_64", vendor: "suse", os: "linux", abi: "gnu"}
+
+      config = %{
+        target_system: target_system,
+        nif_version: "2.14",
+        os_type: {:unix, :linux}
+      }
+
+      assert {:ok, "nif-2.14-x86_64-unknown-linux-gnu"} =
+               RustlerPrecompiled.target(config, @available_targets)
+    end
+
     test "x86_64 or amd64 in a PC running Linux" do
       target_system = %{arch: "amd64", vendor: "pc", os: "linux", abi: "gnu"}
 


### PR DESCRIPTION
Add support for SUSE linux target:
`x86_64-suse-linux-gnu`, which will be aliased to `x86_64-unknown-linux-gnu`.

See #32  and #30 

