### PR TITLE
Also use http_proxy if valid

### DIFF
--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -638,10 +638,11 @@ defmodule RustlerPrecompiled do
     {:ok, _} = Application.ensure_all_started(:inets)
     {:ok, _} = Application.ensure_all_started(:ssl)
 
-    if proxy = System.get_env("HTTP_PROXY") || System.get_env("http_proxy") do
-      Logger.debug("Using HTTP_PROXY: #{proxy}")
-      %{host: host, port: port} = URI.parse(proxy)
+    proxy = System.get_env("HTTP_PROXY") || System.get_env("http_proxy")
 
+    with true <- is_binary(proxy),
+         %{host: host, port: port} when is_binary(host) and is_integer(port) <- URI.parse(proxy) do
+      Logger.debug("Using HTTP_PROXY: #{proxy}")
       :httpc.set_options([{:proxy, {{String.to_charlist(host), port}, []}}])
     end
 


### PR DESCRIPTION
For whatever reason, my system has both `http_` and `https_proxy` environment variables set as empty no matter what I seem to do to unset them in shell init scripts. I see José addressed the https_proxy and these changes duplicate that work to cover the other variable.