### PR TITLE
Map riscv64 to riscv64gc to match Rust naming

### DIFF
--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -390,7 +390,7 @@ defmodule RustlerPrecompiled do
         %{target_system | arch: arch, os: "darwin"}
 
       target_system.os =~ "linux" ->
-        arch = with "amd64" <- target_system.arch, do: "x86_64"
+        arch = normalize_linux_arch(target_system.arch)
 
         vendor =
           with vendor when vendor in ~w(pc redhat suse) <- target_system.vendor, do: "unknown"
@@ -401,6 +401,10 @@ defmodule RustlerPrecompiled do
         target_system
     end
   end
+
+  defp normalize_linux_arch("amd64"), do: "x86_64"
+  defp normalize_linux_arch("riscv64"), do: "riscv64gc"
+  defp normalize_linux_arch(arch), do: arch
 
   defp system_arch_to_string(system_arch) do
     values =

--- a/test/rustler_precompiled_test.exs
+++ b/test/rustler_precompiled_test.exs
@@ -136,6 +136,34 @@ defmodule RustlerPrecompiledTest do
                RustlerPrecompiled.target(config, @available_targets)
     end
 
+    test "riscv64 running a Linux OS" do
+      config = %{
+        target_system: %{arch: "riscv64", vendor: "unknown", os: "linux", abi: "gnu"},
+        nif_version: "2.16",
+        os_type: {:unix, :linux}
+      }
+
+      assert {:ok, "nif-2.16-riscv64gc-unknown-linux-gnu"} =
+               RustlerPrecompiled.target(
+                 config,
+                 @available_targets ++ ["riscv64gc-unknown-linux-gnu"]
+               )
+    end
+
+    test "riscv64 running a Linux OS with MUSL" do
+      config = %{
+        target_system: %{arch: "riscv64", vendor: "unknown", os: "linux", abi: "musl"},
+        nif_version: "2.16",
+        os_type: {:unix, :linux}
+      }
+
+      assert {:ok, "nif-2.16-riscv64gc-unknown-linux-musl"} =
+               RustlerPrecompiled.target(
+                 config,
+                 @available_targets ++ ["riscv64gc-unknown-linux-musl"]
+               )
+    end
+
     test "target not available" do
       config = %{
         target_system: %{arch: "i686", vendor: "unknown", os: "linux", abi: "gnu"},


### PR DESCRIPTION
For 64-bit RISC-V platforms, Nerves passes `riscv64` for the
architecture since that matched the tools (gcc and zig) used when Nerves
was ported to RISC-V. Rust uses `riscv64gc`. The `g` and `c` refer to
instruction sets available on the RISC-V processor, so this is a more
specific name. The `g` says that the processor supports atomics, integer
and floating point math. The `c` shows support for compressed
instructions. To my knowledge, all available 64-bit RISC-V processors
support `gc`, so this is a safe mapping.
