### PR TITLE
Add `riscv64gc-unknown-linux-gnu` as default target

### DIFF
--- a/lib/rustler_precompiled/config.ex
+++ b/lib/rustler_precompiled/config.ex
@@ -19,14 +19,15 @@ defmodule RustlerPrecompiled.Config do
 
   @default_targets ~w(
     aarch64-apple-darwin
+    aarch64-unknown-linux-gnu
     aarch64-unknown-linux-musl
+    arm-unknown-linux-gnueabihf
+    riscv64gc-unknown-linux-gnu
     x86_64-apple-darwin
+    x86_64-pc-windows-gnu
+    x86_64-pc-windows-msvc
     x86_64-unknown-linux-gnu
     x86_64-unknown-linux-musl
-    arm-unknown-linux-gnueabihf
-    aarch64-unknown-linux-gnu
-    x86_64-pc-windows-msvc
-    x86_64-pc-windows-gnu
   )
 
   @available_nif_versions ~w(2.14 2.15 2.16)
@@ -90,9 +91,11 @@ defmodule RustlerPrecompiled.Config do
   defp validate_list!(nil, option, _valid_values), do: raise_for_nil_field_value(option)
 
   defp validate_list!([_ | _] = values, option, valid_values) do
-    case values -- valid_values do
+    uniq_values = Enum.uniq(values)
+
+    case uniq_values -- valid_values do
       [] ->
-        values
+        uniq_values
 
       invalid_values ->
         raise """

--- a/test/rustler_precompiled/config_test.exs
+++ b/test/rustler_precompiled/config_test.exs
@@ -96,14 +96,15 @@ defmodule RustlerPrecompiled.ConfigTest do
 
     assert config.targets == [
              "aarch64-apple-darwin",
-             "aarch64-unknown-linux-musl",
-             "x86_64-apple-darwin",
-             "x86_64-unknown-linux-gnu",
-             "x86_64-unknown-linux-musl",
-             "arm-unknown-linux-gnueabihf",
              "aarch64-unknown-linux-gnu",
+             "aarch64-unknown-linux-musl",
+             "arm-unknown-linux-gnueabihf",
+             "riscv64gc-unknown-linux-gnu",
+             "x86_64-apple-darwin",
+             "x86_64-pc-windows-gnu",
              "x86_64-pc-windows-msvc",
-             "x86_64-pc-windows-gnu"
+             "x86_64-unknown-linux-gnu",
+             "x86_64-unknown-linux-musl"
            ]
   end
 

--- a/test/rustler_precompiled_test.exs
+++ b/test/rustler_precompiled_test.exs
@@ -189,14 +189,15 @@ defmodule RustlerPrecompiledTest do
         precompiled NIF is not available for this target: \"i686-unknown-linux-gnu\".
         The available targets are:
          - aarch64-apple-darwin
+         - aarch64-unknown-linux-gnu
          - aarch64-unknown-linux-musl
+         - arm-unknown-linux-gnueabihf
+         - riscv64gc-unknown-linux-gnu
          - x86_64-apple-darwin
+         - x86_64-pc-windows-gnu
+         - x86_64-pc-windows-msvc
          - x86_64-unknown-linux-gnu
          - x86_64-unknown-linux-musl
-         - arm-unknown-linux-gnueabihf
-         - aarch64-unknown-linux-gnu
-         - x86_64-pc-windows-msvc
-         - x86_64-pc-windows-gnu
         """
         |> String.trim()
 


### PR DESCRIPTION
This is because more machines with RISC-V CPUs are arriving, and they are good for Nerves projects, since they are cheaper then Raspberry Pis.

In this commit there is also a change to prevent duplicated values, since people may already added some of the targets that are in the list of defaults.

Closes https://github.com/philss/rustler_precompiled/issues/44