### PR TITLE
Remove version "2.14" from the default NIF versions

### DIFF
--- a/PRECOMPILATION_GUIDE.md
+++ b/PRECOMPILATION_GUIDE.md
@@ -39,13 +39,13 @@ For this guide our targets will be the following:
 
 - OS: Linux, Windows, macOS
 - Architectures: `x86_64`, `aarch64` (ARM 64 bits), `arm`
-- NIF versions: `2.14`, `2.15`, `2.16`.
+- NIF versions: `2.15`, `2.16`.
 
 In summary the build matrix looks like this:
 
 ```yaml
 matrix:
-  nif: ["2.16", "2.15", "2.14"]
+  nif: ["2.16", "2.15"]
   job:
     - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , use-cross: true }
     - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04 , use-cross: true }
@@ -58,6 +58,8 @@ matrix:
 ```
 
 A complete workflow example can be found in the [`rustler_precompilation_example`](https://github.com/philss/rustler_precompilation_example/blob/main/.github/workflows/release.yml) project.
+That workflow is using a GitHub Action especially made for our goal: [philss/rustler-precompiled-action](https://github.com/philss/rustler-precompiled-action).
+The GitHub Action will deal with the installation of `cross` and the build of the project, naming the files in the correct format.
 
 Some targets are only supported by later versions of `cross`. For those, you might want to
 install `cross` directly from GitHub. You can see an example in [this
@@ -66,7 +68,7 @@ pipeline](https://github.com/kloeckner-i/mail_parser/blob/f4af5083aec73a47f0e41a
 ## Additional configuration before build
 
 In our build we are going to cross compile our crate project (the Rust code for our NIF) using
-a variety of targets as we saw in the previous section. For this to work we need to guide the Rust
+a variety of targets, as we saw in the previous section. For this to work we need to guide the Rust
 compiler in some cases by providing additional configuration in the `.cargo/config` file of our project.
 
 Here is an example of that file:
@@ -150,7 +152,7 @@ With the module I used for this guide, the command would be:
     $ mix rustler_precompiled.download RustlerPrecompilationExample.Native --all --print
 
 The file generated will be named `checksum-Elixir.RustlerPrecompilationExample.Native.exs` and
-it's extremely important that you include this file in your Hex package (by updating the `files:`
+it's **extremely important that you include this file in your Hex package** (by updating the `files:`
 field in your `mix.exs`). Otherwise your package **won't work**. Your `files:` key at your
 package configuration will look like this:
 

--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -47,10 +47,20 @@ defmodule RustlerPrecompiled do
 
     #{Enum.map_join(RustlerPrecompiled.Config.default_targets(), "\n", &"    - `#{&1}`")}
 
-    * `:nif_versions` - A list of OTP nif_versions for which precompiled assets are
-      available. By default the following nif_versions are configured:
+    * `:nif_versions` - A list of OTP NIF versions for which precompiled assets are
+      available. A NIF version is usually compatible with two OTP minor versions, and an older
+      NIF is usually compatible with newer OTPs. The available versions are the following: 
 
-    #{Enum.map_join(RustlerPrecompiled.Config.available_nif_versions(), "\n", &"    - `#{&1}`")}
+      * `2.14` - for OTP 21.
+      * `2.15` - for OTP 22 and 23.
+      * `2.16` - for OTP 24 and 25.
+
+      By default the following NIF versions are configured:
+
+    #{Enum.map_join(RustlerPrecompiled.Config.default_nif_versions(), "\n", &"    - `#{&1}`")}
+
+      Check the compatibiliy table between Elixir and OTP in:
+      https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
 
   In case "force build" is used, all options except `:base_url`, `:version`,
   `:force_build`, `:nif_versions`, and `:targets` are going to be passed down to `Rustler`.

--- a/lib/rustler_precompiled/config.ex
+++ b/lib/rustler_precompiled/config.ex
@@ -31,10 +31,12 @@ defmodule RustlerPrecompiled.Config do
   )
 
   @available_nif_versions ~w(2.14 2.15 2.16)
+  @default_nif_versions ~w(2.15 2.16)
 
   def default_targets, do: @default_targets
 
   def available_nif_versions, do: @available_nif_versions
+  def default_nif_versions, do: @default_nif_versions
 
   def new(opts) do
     version = Keyword.fetch!(opts, :version)
@@ -48,7 +50,7 @@ defmodule RustlerPrecompiled.Config do
 
     nif_versions =
       opts
-      |> Keyword.get(:nif_versions, @available_nif_versions)
+      |> Keyword.get(:nif_versions, @default_nif_versions)
       |> validate_list!(:nif_versions, @available_nif_versions)
 
     %__MODULE__{

--- a/test/rustler_precompiled/config_test.exs
+++ b/test/rustler_precompiled/config_test.exs
@@ -161,7 +161,6 @@ defmodule RustlerPrecompiled.ConfigTest do
       )
 
     assert config.nif_versions == [
-             "2.14",
              "2.15",
              "2.16"
            ]


### PR DESCRIPTION
That version is targeting OTP 21, which is fairly old. We can speed up the release time of libs without this version.