### PR TITLE
Add support for freebsd

### DIFF
--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -454,6 +454,13 @@ defmodule RustlerPrecompiled do
 
         %{target_system | arch: arch, vendor: vendor}
 
+      target_system.os =~ "freebsd" ->
+        arch = normalize_linux_arch(target_system.arch)
+
+        vendor = with "portbld" <- target_system.vendor, do: "unknown"
+
+        %{target_system | arch: arch, vendor: vendor, os: "freebsd"}
+
       true ->
         target_system
     end

--- a/lib/rustler_precompiled/config.ex
+++ b/lib/rustler_precompiled/config.ex
@@ -28,6 +28,7 @@ defmodule RustlerPrecompiled.Config do
     x86_64-pc-windows-msvc
     x86_64-unknown-linux-gnu
     x86_64-unknown-linux-musl
+    x86_64-unknown-freebsd
   )
 
   @available_nif_versions ~w(2.14 2.15 2.16)

--- a/test/rustler_precompiled/config_test.exs
+++ b/test/rustler_precompiled/config_test.exs
@@ -104,7 +104,8 @@ defmodule RustlerPrecompiled.ConfigTest do
              "x86_64-pc-windows-gnu",
              "x86_64-pc-windows-msvc",
              "x86_64-unknown-linux-gnu",
-             "x86_64-unknown-linux-musl"
+             "x86_64-unknown-linux-musl",
+             "x86_64-unknown-freebsd"
            ]
   end
 

--- a/test/rustler_precompiled_test.exs
+++ b/test/rustler_precompiled_test.exs
@@ -167,6 +167,19 @@ defmodule RustlerPrecompiledTest do
                )
     end
 
+    test "amd64 running FreeBSD" do
+      target_system = %{arch: "amd64", vendor: "portbld", os: "freebsd13.1"}
+
+      config = %{
+        target_system: target_system,
+        nif_version: "2.16",
+        os_type: {:unix, :freebsd}
+      }
+
+      assert {:ok, "nif-2.16-x86_64-unknown-freebsd"} =
+               RustlerPrecompiled.target(config, @available_targets, @available_nif_versions)
+    end
+
     test "without specified available_targets or available_nif_versions" do
       config = %{
         target_system: %{arch: "arm", vendor: "unknown", os: "linux", abi: "gnueabihf"},
@@ -198,6 +211,7 @@ defmodule RustlerPrecompiledTest do
          - x86_64-pc-windows-msvc
          - x86_64-unknown-linux-gnu
          - x86_64-unknown-linux-musl
+         - x86_64-unknown-freebsd
         """
         |> String.trim()
 


### PR DESCRIPTION
As discussed in https://github.com/elixir-nx/explorer/pull/618, this adds support for freebsd.

`amd64-portbld-freebsd13.1` will be normalized to `x86_64-unknown-freebsd`.

Let me know what you think.