### PR TITLE
Change defaults for upcoming v0.7

### DIFF
--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -71,12 +71,12 @@ defmodule RustlerPrecompiled do
       restrict CPU features, like AVX on x86_64.
 
       The order of variants matters, because the first one that returns `true` is going to be
-      selected. Example: 
+      selected. Example:
 
           %{"x86_64-unknown-linux-gnu" => [old_glibc: fn _config -> has_old_glibc?() end]}
 
-  In case "force build" is used, all options except `:base_url`, `:version`,
-  `:force_build`, `:nif_versions`, and `:targets` are going to be passed down to `Rustler`.
+  In case "force build" is used, all options except the ones use by RustlerPrecompiled
+  are going to be passed down to `Rustler`.
   So if you need to configure the build, check the `Rustler` options.
 
   ## Environment variables

--- a/lib/rustler_precompiled/config.ex
+++ b/lib/rustler_precompiled/config.ex
@@ -30,8 +30,8 @@ defmodule RustlerPrecompiled.Config do
     x86_64-unknown-linux-musl
   )
 
-  @available_nif_versions ~w(2.14 2.15 2.16)
-  @default_nif_versions ~w(2.15 2.16)
+  @available_nif_versions ~w(2.14 2.15 2.16 2.17)
+  @default_nif_versions ~w(2.15)
 
   def default_targets, do: @default_targets
   def available_targets, do: RustlerPrecompiled.Config.AvailableTargets.list()

--- a/test/rustler_precompiled/config_test.exs
+++ b/test/rustler_precompiled/config_test.exs
@@ -161,8 +161,7 @@ defmodule RustlerPrecompiled.ConfigTest do
       )
 
     assert config.nif_versions == [
-             "2.15",
-             "2.16"
+             "2.15"
            ]
   end
 

--- a/test/rustler_precompiled_test.exs
+++ b/test/rustler_precompiled_test.exs
@@ -5,6 +5,7 @@ defmodule RustlerPrecompiledTest do
 
   @available_targets RustlerPrecompiled.Config.default_targets()
   @available_nif_versions RustlerPrecompiled.Config.available_nif_versions()
+  @default_nif_versions RustlerPrecompiled.Config.default_nif_versions()
 
   describe "target/1" do
     test "arm 64 bits in an Apple with Darwin-based OS" do
@@ -369,7 +370,7 @@ defmodule RustlerPrecompiledTest do
               version: "0.2.0",
               crate: "example",
               targets: @available_targets,
-              nif_versions: @available_nif_versions
+              nif_versions: @default_nif_versions
             }
 
             {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
@@ -417,7 +418,7 @@ defmodule RustlerPrecompiledTest do
               version: "0.2.0",
               crate: "example",
               targets: @available_targets,
-              nif_versions: @available_nif_versions
+              nif_versions: @default_nif_versions
             }
 
             {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
@@ -474,7 +475,7 @@ defmodule RustlerPrecompiledTest do
               version: "0.2.0",
               crate: "example",
               targets: @available_targets,
-              nif_versions: @available_nif_versions
+              nif_versions: @default_nif_versions
             }
 
             {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
@@ -526,7 +527,7 @@ defmodule RustlerPrecompiledTest do
             crate: "example",
             max_retries: 0,
             targets: @available_targets,
-            nif_versions: @available_nif_versions
+            nif_versions: @default_nif_versions
           }
 
           {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
@@ -564,7 +565,7 @@ defmodule RustlerPrecompiledTest do
             version: "0.2.0",
             crate: "example",
             targets: @available_targets,
-            nif_versions: @available_nif_versions
+            nif_versions: @default_nif_versions
           }
 
           {:ok, metadata} = RustlerPrecompiled.build_metadata(config)

--- a/test/rustler_precompiled_test.exs
+++ b/test/rustler_precompiled_test.exs
@@ -819,7 +819,7 @@ defmodule RustlerPrecompiledTest do
       assert {:ok, nif_urls} = RustlerPrecompiled.nif_urls_from_metadata(metadata)
 
       # NIF versions multiplied by 2 new variants.
-      variants_count = 6
+      variants_count = 8
 
       assert length(nif_urls) ==
                length(@available_targets) * length(@available_nif_versions) + variants_count

--- a/test/rustler_precompiled_test.exs
+++ b/test/rustler_precompiled_test.exs
@@ -229,7 +229,7 @@ defmodule RustlerPrecompiledTest do
       }
 
       error_message =
-        "precompiled NIF is not available for this NIF version: \"2.10\".\nThe available NIF versions are:\n - 2.14\n - 2.15\n - 2.16"
+        "precompiled NIF is not available for this NIF version: \"2.10\".\nThe available NIF versions are:\n - 2.14\n - 2.15\n - 2.16\n - 2.17"
 
       assert {:error, ^error_message} =
                RustlerPrecompiled.target(config, @available_targets, @available_nif_versions)


### PR DESCRIPTION
Normally users need to build only for the lowest NIF version, unless they need specific features from newer versions.