### PR TITLE
Make sure `:nif_versions` option is respect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2023-08-28
+
+### Fixed
+
+- Make sure `:nif_versions` option is respected.
+
+  This is a small bug fix that was blocking the usage of a more
+  restrict list of "NIF versions". For example, if my system is
+  using NIF version 2.16, but I want to be compatible with only
+  version 2.15, this was being ignored, since the algorithm for
+  finding compatible versions was not taking into account this
+  restriction.
+
 ## [0.6.2] - 2023-07-05
 
 ### Added
@@ -151,7 +164,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add basic features to download and use the precompiled NIFs in a safe way.
 
-[Unreleased]: https://github.com/philss/rustler_precompiled/compare/v0.6.2...HEAD
+[Unreleased]: https://github.com/philss/rustler_precompiled/compare/v0.6.3...HEAD
+[0.6.3]: https://github.com/philss/rustler_precompiled/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/philss/rustler_precompiled/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/philss/rustler_precompiled/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/philss/rustler_precompiled/compare/v0.5.5...v0.6.0

--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -337,11 +337,11 @@ defmodule RustlerPrecompiled do
     end
   end
 
-  defp target_config do
+  defp target_config(available_nif_versions \\ Config.available_nif_versions()) do
     current_nif_version = :erlang.system_info(:nif_version) |> List.to_string()
 
     nif_version =
-      case find_compatible_nif_version(current_nif_version, Config.available_nif_versions()) do
+      case find_compatible_nif_version(current_nif_version, available_nif_versions) do
         {:ok, vsn} ->
           vsn
 
@@ -495,7 +495,7 @@ defmodule RustlerPrecompiled do
       version: config.version
     }
 
-    case target(target_config(), config.targets, config.nif_versions) do
+    case target(target_config(config.nif_versions), config.targets, config.nif_versions) do
       {:ok, target} ->
         basename = config.crate || config.otp_app
         lib_name = "#{lib_prefix(target)}#{basename}-v#{config.version}-#{target}"

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule RustlerPrecompiled.MixProject do
   use Mix.Project
 
-  @version "0.6.2"
+  @version "0.6.3"
   @repo "https://github.com/philss/rustler_precompiled"
 
   def project do

--- a/test/rustler_precompiled_test.exs
+++ b/test/rustler_precompiled_test.exs
@@ -552,12 +552,12 @@ defmodule RustlerPrecompiledTest do
         version: "0.2.0",
         crate: "example",
         targets: @available_targets,
-        nif_versions: ["future_nif_version"]
+        nif_versions: ["4.2"]
       }
 
       assert {:error, error} = RustlerPrecompiled.build_metadata(config)
       assert error =~ "precompiled NIF is not available for this NIF version: "
-      assert error =~ ".\nThe available NIF versions are:\n - future_nif_version"
+      assert error =~ ".\nThe available NIF versions are:\n - 4.2"
     end
 
     test "returns a base metadata when nif_version is not available but force build is enabled" do
@@ -569,7 +569,7 @@ defmodule RustlerPrecompiledTest do
         version: "0.2.0",
         crate: "example",
         targets: @available_targets,
-        nif_versions: ["future_nif_version"],
+        nif_versions: ["4.2"],
         force_build?: true
       }
 
@@ -578,9 +578,26 @@ defmodule RustlerPrecompiledTest do
       assert base_metadata[:otp_app] == :rustler_precompiled
       assert base_metadata[:crate] == "example"
       assert base_metadata[:targets] == @available_targets
-      assert base_metadata[:nif_versions] == ["future_nif_version"]
+      assert base_metadata[:nif_versions] == ["4.2"]
       assert base_metadata[:version] == "0.2.0"
       assert base_metadata[:base_url] == config.base_url
+    end
+
+    test "builds a valid metadata with a restrict NIF versions list" do
+      config = %RustlerPrecompiled.Config{
+        otp_app: :rustler_precompiled,
+        module: RustlerPrecompilationExample.Native,
+        base_url:
+          "https://github.com/philss/rustler_precompilation_example/releases/download/v0.2.0",
+        version: "0.2.0",
+        crate: "example",
+        targets: @available_targets,
+        nif_versions: ["2.15"]
+      }
+
+      assert {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
+
+      assert metadata.nif_versions == ["2.15"]
     end
   end
 


### PR DESCRIPTION
This is a small bug fix that was blocking the usage of a more restrict list of "NIF versions". For example, if my system is using NIF version 2.16, but I want to be compatible with only version 2.15, this was being ignored, since the algorithm for finding compatible versions was not taking into account this restriction.