### PR TITLE
Add support for variants targets

### DIFF
--- a/lib/mix/tasks/rustler_precompiled.download.ex
+++ b/lib/mix/tasks/rustler_precompiled.download.ex
@@ -39,7 +39,7 @@ defmodule Mix.Tasks.RustlerPrecompiled.Download do
           RustlerPrecompiled.available_nif_urls(module)
 
         Keyword.get(options, :only_local) ->
-          [RustlerPrecompiled.current_target_nif_url(module)]
+          RustlerPrecompiled.current_target_nif_urls(module)
 
         true ->
           raise "you need to specify either \"--all\" or \"--only-local\" flags"

--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -297,11 +297,12 @@ defmodule RustlerPrecompiled do
   defp maybe_variants_tar_gz_urls(_, _, _, _), do: []
 
   @doc """
-  Returns the file URL to be downloaded for current target.
+  Returns the file URLs to be downloaded for current target.
 
+  It is in the plural because a target may have some variants for it.
   It receives the NIF module.
   """
-  def current_target_nif_url(nif_module) when is_atom(nif_module) do
+  def current_target_nif_urls(nif_module) when is_atom(nif_module) do
     metadata =
       nif_module
       |> metadata_file()
@@ -309,7 +310,17 @@ defmodule RustlerPrecompiled do
 
     case metadata do
       %{base_url: base_url, file_name: file_name} ->
-        tar_gz_file_url(base_url, file_name)
+        target_triple = target_triple_from_nif_target(metadata[:target])
+
+        variants =
+          maybe_variants_tar_gz_urls(
+            metadata[:variants],
+            base_url,
+            target_triple,
+            metadata[:lib_name]
+          )
+
+        [tar_gz_file_url(base_url, file_name) | variants]
 
       _ ->
         raise "metadata about current target for the module #{inspect(nif_module)} is not available. " <>

--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -66,6 +66,15 @@ defmodule RustlerPrecompiled do
     * `:max_retries` - The maximum of retries before giving up. Defaults to `3`.
       Retries can be disabled with `0`.
 
+    * `:variants` - A map with alternative versions of a given target. This is useful to
+      support specific versions of dependencies, such as an old glibc version, or to support
+      restrict CPU features, like AVX on x86_64.
+
+      The order of variants matters, because the first one that returns `true` is going to be
+      selected. Example: 
+
+          %{"x86_64-unknown-linux-gnu" => [{"old-glibc", fn _config -> has_old_glibc?() end}]}
+
   In case "force build" is used, all options except `:base_url`, `:version`,
   `:force_build`, `:nif_versions`, and `:targets` are going to be passed down to `Rustler`.
   So if you need to configure the build, check the `Rustler` options.
@@ -180,7 +189,8 @@ defmodule RustlerPrecompiled do
               :force_build,
               :targets,
               :nif_versions,
-              :max_retries
+              :max_retries,
+              :variants
             ])
 
           {:force_build, rustler_opts}
@@ -501,6 +511,7 @@ defmodule RustlerPrecompiled do
       crate: config.crate,
       otp_app: config.otp_app,
       targets: config.targets,
+      variants: variants_for_metadata(config.variants),
       nif_versions: config.nif_versions,
       version: config.version
     }
@@ -508,7 +519,12 @@ defmodule RustlerPrecompiled do
     case target(target_config(config.nif_versions), config.targets, config.nif_versions) do
       {:ok, target} ->
         basename = config.crate || config.otp_app
-        lib_name = "#{lib_prefix(target)}#{basename}-v#{config.version}-#{target}"
+
+        # Extract the target without the nif-NIF-VERSION part
+        [_, _, os_arch_target] = String.split(target, "-", parts: 3)
+
+        variant = variant_suffix(os_arch_target, config)
+        lib_name = "#{lib_prefix(target)}#{basename}-v#{config.version}-#{target}#{variant}"
 
         file_name = lib_name_with_ext(target, lib_name)
 
@@ -533,6 +549,27 @@ defmodule RustlerPrecompiled do
         end
     end
   end
+
+  defp variants_for_metadata(variants) do
+    variants
+    |> Enum.map(fn {target, values} -> {target, Keyword.keys(values)} end)
+    |> Map.new()
+  end
+
+  defp variant_suffix(target, %{variants: variants} = config) when is_map_key(variants, target) do
+    variants = Map.fetch!(variants, target)
+
+    variant = Enum.find(variants, fn {_name, func} -> func.(config) end)
+
+    if is_nil(variant) do
+      ""
+    else
+      {name, _} = variant
+      "--" <> Atom.to_string(name)
+    end
+  end
+
+  defp variant_suffix(_, _), do: IO.inspect("", label: "none")
 
   # Perform the download or load of the precompiled NIF
   # It will look in the "priv/native/otp_app" first, and if

--- a/lib/rustler_precompiled/config.ex
+++ b/lib/rustler_precompiled/config.ex
@@ -13,6 +13,7 @@ defmodule RustlerPrecompiled.Config do
     :force_build?,
     :targets,
     :nif_versions,
+    :variants,
     max_retries: 3
   ]
 
@@ -65,6 +66,7 @@ defmodule RustlerPrecompiled.Config do
       base_cache_dir: opts[:base_cache_dir],
       targets: targets,
       nif_versions: nif_versions,
+      variants: %{},
       max_retries: validate_max_retries!(Keyword.get(opts, :max_retries, 3))
     }
   end

--- a/lib/rustler_precompiled/config.ex
+++ b/lib/rustler_precompiled/config.ex
@@ -13,7 +13,7 @@ defmodule RustlerPrecompiled.Config do
     :force_build?,
     :targets,
     :nif_versions,
-    :variants,
+    variants: %{},
     max_retries: 3
   ]
 
@@ -66,7 +66,7 @@ defmodule RustlerPrecompiled.Config do
       base_cache_dir: opts[:base_cache_dir],
       targets: targets,
       nif_versions: nif_versions,
-      variants: %{},
+      variants: validate_variants!(targets, Keyword.get(opts, :variants, %{})),
       max_retries: validate_max_retries!(Keyword.get(opts, :max_retries, 3))
     }
   end
@@ -127,4 +127,30 @@ defmodule RustlerPrecompiled.Config do
   end
 
   defp pre_release?(version), do: "dev" in Version.parse!(version).pre
+
+  defp validate_variants!(_, nil), do: %{}
+
+  defp validate_variants!(targets, variants) when is_map(variants) do
+    variants_targets = Map.keys(variants)
+
+    for target <- variants_targets do
+      if target not in targets do
+        raise "`:variants` contains a target that is not in the list of valid targets: #{inspect(target)}"
+      end
+
+      possibilities = Map.fetch!(variants, target)
+
+      for {name, fun} <- possibilities do
+        if not is_atom(name) do
+          raise "`:variants` expects a keyword list as values, but found a key that is not an atom: #{inspect(name)}"
+        end
+
+        if not (is_function(fun, 0) or is_function(fun, 1)) do
+          raise "`:variants` expects a keyword list as values with functions to detect if a given variant is to be activated"
+        end
+      end
+    end
+
+    variants
+  end
 end

--- a/test/rustler_precompiled_test.exs
+++ b/test/rustler_precompiled_test.exs
@@ -756,7 +756,6 @@ defmodule RustlerPrecompiledTest do
 
       assert metadata.variants == %{"x86_64-unknown-linux-gnu" => [:old_glibc, :legacy_cpus]}
 
-      # We need this guard because not every one is running the tests in the same OS/Arch.
       if metadata.lib_name =~ "x86_64-unknown-linux-gnu" do
         assert String.ends_with?(metadata.lib_name, "--legacy_cpus")
         assert String.ends_with?(metadata.file_name, "--legacy_cpus.so")


### PR DESCRIPTION
This feature introduces variants, which are alternative versions that can be configured in compile time to
load a specific precompiled NIF depending on the result of callback functions.

This enables developers to set different versions for the same target, depending on which versions of dependencies the target machine has.
Remember that the callback will always run at compile time, in the machine that is doing the compilation.

This may be enough to fix https://github.com/philss/rustler_precompiled/issues/59 and https://github.com/elixir-explorer/explorer/issues/590

## TODOs

- [x] update the [rustler-precompiled-action](https://github.com/philss/rustler-precompiled-action) to support variants => https://github.com/philss/rustler-precompiled-action/pull/5
- [x] test it with the [example project](https://github.com/philss/rustler_precompilation_example) => https://github.com/philss/rustler_precompilation_example