### PR TITLE
Add support for setting a global cache path using an env var

### DIFF
--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -190,6 +190,7 @@ defmodule RustlerPrecompiled do
         # We need to write metadata in order to run Mix tasks.
         with {:error, error} <- write_metadata(module, metadata) do
           require Logger
+
           Logger.warning(
             "Cannot write metadata file for module #{inspect(module)}. Reason: #{inspect(error)}. " <>
               "This is only an issue if you need to use the rustler_precompiled mix tasks for publishing a package."


### PR DESCRIPTION
This is a feature that can help people with internet access restrictions or writing permission limitations.

It may help people that need to support systems running on NixOS or a Nix environment.

In a nutshell, first download the desired ".tar.gz" artifact for a given package, set the `RUSTLER_PRECOMPILED_GLOBAL_CACHE_PATH` to the directory that the package was downloaded, and then build your project normally.