### PR TITLE
Add support for headers and dynamic base URL (#65)

### DIFF
--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -305,12 +305,8 @@ defmodule RustlerPrecompiled do
 
   @doc false
   def nif_urls_from_metadata(metadata) when is_map(metadata) do
-    case(nifs_from_metadata(metadata)) do
-      {:ok, nifs} ->
-        {:ok, Enum.map(nifs, fn {_lib_name, {url, _headers}} -> url end)}
-
-      {:error, wrong_meta} ->
-        {:error, wrong_meta}
+    with {:ok, nifs} <- nifs_from_metadata(metadata) do
+      {:ok, Enum.map(nifs, fn {_lib_name, {url, _headers}} -> url end)}
     end
   end
 
@@ -359,7 +355,8 @@ defmodule RustlerPrecompiled do
 
   @doc deprecated: "Use current_target_nifs/1 instead"
   def current_target_nif_urls(nif_module) when is_atom(nif_module) do
-    current_target_nifs(nif_module)
+    nif_module
+    |> current_target_nifs()
     |> Enum.map(fn {_lib_name, {url, _headers}} -> url end)
   end
 

--- a/lib/rustler_precompiled/config.ex
+++ b/lib/rustler_precompiled/config.ex
@@ -90,10 +90,10 @@ defmodule RustlerPrecompiled.Config do
   defp validate_base_url!({base_url, headers}) when is_binary(base_url) and is_list(headers) do
     case :uri_string.parse(base_url) do
       %{} ->
-        if Enum.all?(headers, &match?({key, value} when is_list(key) and is_binary(value), &1)) do
+        if Enum.all?(headers, &match?({key, value} when is_binary(key) and is_binary(value), &1)) do
           {base_url, headers}
         else
-          raise "`:base_url` for `RustlerPrecompiled` must be a list of `{charlist(),binary()}`"
+          raise "`:base_url` headers for `RustlerPrecompiled` must be a list of `{binary(),binary()}`"
         end
 
       {:error, :invalid_uri, error} ->

--- a/test/rustler_precompiled_test.exs
+++ b/test/rustler_precompiled_test.exs
@@ -501,6 +501,111 @@ defmodule RustlerPrecompiledTest do
     end
 
     @tag :tmp_dir
+    test "a project downloading precompiled NIFs with custom header", %{
+      tmp_dir: tmp_dir,
+      checksum_sample: checksum_sample,
+      nif_fixtures_dir: nif_fixtures_dir
+    } do
+      bypass = Bypass.open()
+
+      in_tmp(tmp_dir, fn ->
+        File.write!("checksum-Elixir.RustlerPrecompilationExample.Native.exs", checksum_sample)
+
+        Bypass.expect_once(bypass, fn conn ->
+          file_name = List.last(conn.path_info)
+          file = File.read!(Path.join([nif_fixtures_dir, "precompiled_nifs", file_name]))
+
+          if Plug.Conn.get_req_header(conn, "authorization") == ["Token 123"] do
+            Plug.Conn.resp(conn, 200, file)
+          else
+            Plug.Conn.resp(conn, 401, "Unauthorized")
+          end
+        end)
+
+        result =
+          capture_log(fn ->
+            config = %RustlerPrecompiled.Config{
+              otp_app: :rustler_precompiled,
+              module: RustlerPrecompilationExample.Native,
+              base_cache_dir: tmp_dir,
+              base_url:
+                {"http://localhost:#{bypass.port}/download", [{"authorization", "Token 123"}]},
+              version: "0.2.0",
+              crate: "example",
+              targets: @available_targets,
+              nif_versions: @default_nif_versions
+            }
+
+            {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
+
+            assert {:ok, result} = RustlerPrecompiled.download_or_reuse_nif_file(config, metadata)
+
+            assert result.load?
+            assert {:rustler_precompiled, path} = result.load_from
+
+            assert path =~ "priv/native"
+            assert path =~ "example-v0.2.0-nif"
+          end)
+
+        assert result =~ "Downloading"
+        assert result =~ "http://localhost:#{bypass.port}/download"
+        assert result =~ "NIF cached at"
+      end)
+    end
+
+    @tag :tmp_dir
+    test "a project downloading precompiled NIFs with custom handler", %{
+      tmp_dir: tmp_dir,
+      checksum_sample: checksum_sample,
+      nif_fixtures_dir: nif_fixtures_dir
+    } do
+      bypass = Bypass.open(port: 1234)
+
+      in_tmp(tmp_dir, fn ->
+        File.write!("checksum-Elixir.RustlerPrecompilationExample.Native.exs", checksum_sample)
+
+        Bypass.expect_once(bypass, fn conn ->
+          %{"file_name" => file_name} = URI.decode_query(conn.query_string)
+          file = File.read!(Path.join([nif_fixtures_dir, "precompiled_nifs", file_name]))
+
+          if Plug.Conn.get_req_header(conn, "authorization") == ["Token 123"] do
+            Plug.Conn.resp(conn, 200, file)
+          else
+            Plug.Conn.resp(conn, 401, "Unauthorized")
+          end
+        end)
+
+        result =
+          capture_log(fn ->
+            config = %RustlerPrecompiled.Config{
+              otp_app: :rustler_precompiled,
+              module: RustlerPrecompilationExample.Native,
+              base_cache_dir: tmp_dir,
+              base_url: {__MODULE__, :url_with_headers},
+              version: "0.2.0",
+              crate: "example",
+              targets: @available_targets,
+              nif_versions: @default_nif_versions
+            }
+
+            {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
+
+            assert {:ok, result} = RustlerPrecompiled.download_or_reuse_nif_file(config, metadata)
+
+            assert result.load?
+            assert {:rustler_precompiled, path} = result.load_from
+
+            assert path =~ "priv/native"
+            assert path =~ "example-v0.2.0-nif"
+          end)
+
+        assert result =~ "Downloading"
+        assert result =~ "http://localhost:#{bypass.port}/download"
+        assert result =~ "NIF cached at"
+      end)
+    end
+
+    @tag :tmp_dir
     test "a project downloading precompiled NIFs with retry", %{
       tmp_dir: tmp_dir,
       checksum_sample: checksum_sample,
@@ -793,7 +898,7 @@ defmodule RustlerPrecompiledTest do
       # We need this guard because not every one is running the tests in the same OS/Arch.
       if metadata.lib_name =~ "x86_64-unknown-linux-gnu" do
         assert String.ends_with?(metadata.lib_name, "--old_glibc")
-        assert String.ends_with?(metadata.file_name, "--old_glibc.so")
+        assert String.ends_with?(metadata.file_name, "--old_glibc.so.tar.gz")
       end
     end
 
@@ -821,7 +926,7 @@ defmodule RustlerPrecompiledTest do
 
       if metadata.lib_name =~ "x86_64-unknown-linux-gnu" do
         assert String.ends_with?(metadata.lib_name, "--legacy_cpus")
-        assert String.ends_with?(metadata.file_name, "--legacy_cpus.so")
+        assert String.ends_with?(metadata.file_name, "--legacy_cpus.so.tar.gz")
       end
     end
   end
@@ -954,5 +1059,10 @@ defmodule RustlerPrecompiledTest do
     |> :crypto.strong_rand_bytes()
     |> Base.encode64()
     |> binary_part(0, len)
+  end
+
+  def url_with_headers(file_name) do
+    {"http://localhost:1234/download?file_name=#{file_name}&foo=bar",
+     [{"authorization", "Token 123"}]}
   end
 end

--- a/test/rustler_precompiled_test.exs
+++ b/test/rustler_precompiled_test.exs
@@ -423,17 +423,19 @@ defmodule RustlerPrecompiledTest do
 
         result =
           capture_log(fn ->
-            config = %RustlerPrecompiled.Config{
-              otp_app: :rustler_precompiled,
-              module: RustlerPrecompilationExample.Native,
-              base_cache_dir: nif_fixtures_dir,
-              base_url:
-                "https://github.com/philss/rustler_precompilation_example/releases/download/v0.2.0",
-              version: "0.2.0",
-              crate: "example",
-              targets: @available_targets,
-              nif_versions: @default_nif_versions
-            }
+            config =
+              RustlerPrecompiled.Config.new(
+                otp_app: :rustler_precompiled,
+                module: RustlerPrecompilationExample.Native,
+                base_cache_dir: nif_fixtures_dir,
+                base_url:
+                  "https://github.com/philss/rustler_precompilation_example/releases/download/v0.2.0",
+                version: "0.2.0",
+                crate: "example",
+                targets: @available_targets,
+                nif_versions: @default_nif_versions,
+                force_build: false
+              )
 
             {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
 
@@ -472,16 +474,18 @@ defmodule RustlerPrecompiledTest do
 
         result =
           capture_log(fn ->
-            config = %RustlerPrecompiled.Config{
-              otp_app: :rustler_precompiled,
-              module: RustlerPrecompilationExample.Native,
-              base_cache_dir: tmp_dir,
-              base_url: "http://localhost:#{bypass.port}/download",
-              version: "0.2.0",
-              crate: "example",
-              targets: @available_targets,
-              nif_versions: @default_nif_versions
-            }
+            config =
+              RustlerPrecompiled.Config.new(
+                otp_app: :rustler_precompiled,
+                module: RustlerPrecompilationExample.Native,
+                base_cache_dir: tmp_dir,
+                base_url: "http://localhost:#{bypass.port}/download",
+                version: "0.2.0",
+                crate: "example",
+                targets: @available_targets,
+                nif_versions: @default_nif_versions,
+                force_build: false
+              )
 
             {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
 
@@ -524,17 +528,19 @@ defmodule RustlerPrecompiledTest do
 
         result =
           capture_log(fn ->
-            config = %RustlerPrecompiled.Config{
-              otp_app: :rustler_precompiled,
-              module: RustlerPrecompilationExample.Native,
-              base_cache_dir: tmp_dir,
-              base_url:
-                {"http://localhost:#{bypass.port}/download", [{"authorization", "Token 123"}]},
-              version: "0.2.0",
-              crate: "example",
-              targets: @available_targets,
-              nif_versions: @default_nif_versions
-            }
+            config =
+              RustlerPrecompiled.Config.new(
+                otp_app: :rustler_precompiled,
+                module: RustlerPrecompilationExample.Native,
+                base_cache_dir: tmp_dir,
+                base_url:
+                  {"http://localhost:#{bypass.port}/download", [{"authorization", "Token 123"}]},
+                version: "0.2.0",
+                crate: "example",
+                targets: @available_targets,
+                nif_versions: @default_nif_versions,
+                force_build: false
+              )
 
             {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
 
@@ -577,16 +583,18 @@ defmodule RustlerPrecompiledTest do
 
         result =
           capture_log(fn ->
-            config = %RustlerPrecompiled.Config{
-              otp_app: :rustler_precompiled,
-              module: RustlerPrecompilationExample.Native,
-              base_cache_dir: tmp_dir,
-              base_url: {__MODULE__, :url_with_headers},
-              version: "0.2.0",
-              crate: "example",
-              targets: @available_targets,
-              nif_versions: @default_nif_versions
-            }
+            config =
+              RustlerPrecompiled.Config.new(
+                otp_app: :rustler_precompiled,
+                module: RustlerPrecompilationExample.Native,
+                base_cache_dir: tmp_dir,
+                base_url: {__MODULE__, :url_with_headers},
+                version: "0.2.0",
+                crate: "example",
+                targets: @available_targets,
+                nif_versions: @default_nif_versions,
+                force_build: false
+              )
 
             {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
 
@@ -634,16 +642,18 @@ defmodule RustlerPrecompiledTest do
 
         result =
           capture_log(fn ->
-            config = %RustlerPrecompiled.Config{
-              otp_app: :rustler_precompiled,
-              module: RustlerPrecompilationExample.Native,
-              base_cache_dir: tmp_dir,
-              base_url: "http://localhost:#{bypass.port}/download",
-              version: "0.2.0",
-              crate: "example",
-              targets: @available_targets,
-              nif_versions: @default_nif_versions
-            }
+            config =
+              RustlerPrecompiled.Config.new(
+                otp_app: :rustler_precompiled,
+                module: RustlerPrecompilationExample.Native,
+                base_cache_dir: tmp_dir,
+                base_url: "http://localhost:#{bypass.port}/download",
+                version: "0.2.0",
+                crate: "example",
+                targets: @available_targets,
+                nif_versions: @default_nif_versions,
+                force_build: false
+              )
 
             {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
 
@@ -685,17 +695,19 @@ defmodule RustlerPrecompiledTest do
         end)
 
         capture_log(fn ->
-          config = %RustlerPrecompiled.Config{
-            otp_app: :rustler_precompiled,
-            module: RustlerPrecompilationExample.Native,
-            base_cache_dir: tmp_dir,
-            base_url: "http://localhost:#{bypass.port}/download",
-            version: "0.2.0",
-            crate: "example",
-            max_retries: 0,
-            targets: @available_targets,
-            nif_versions: @default_nif_versions
-          }
+          config =
+            RustlerPrecompiled.Config.new(
+              otp_app: :rustler_precompiled,
+              module: RustlerPrecompilationExample.Native,
+              base_cache_dir: tmp_dir,
+              base_url: "http://localhost:#{bypass.port}/download",
+              version: "0.2.0",
+              crate: "example",
+              max_retries: 0,
+              targets: @available_targets,
+              nif_versions: @default_nif_versions,
+              force_build: false
+            )
 
           {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
 
@@ -724,16 +736,18 @@ defmodule RustlerPrecompiledTest do
         end)
 
         capture_log(fn ->
-          config = %RustlerPrecompiled.Config{
-            otp_app: :rustler_precompiled,
-            module: RustlerPrecompilationExample.Native,
-            base_cache_dir: tmp_dir,
-            base_url: "http://localhost:#{bypass.port}/download",
-            version: "0.2.0",
-            crate: "example",
-            targets: @available_targets,
-            nif_versions: @default_nif_versions
-          }
+          config =
+            RustlerPrecompiled.Config.new(
+              otp_app: :rustler_precompiled,
+              module: RustlerPrecompilationExample.Native,
+              base_cache_dir: tmp_dir,
+              base_url: "http://localhost:#{bypass.port}/download",
+              version: "0.2.0",
+              crate: "example",
+              targets: @available_targets,
+              nif_versions: @default_nif_versions,
+              force_build: false
+            )
 
           {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
 
@@ -750,17 +764,19 @@ defmodule RustlerPrecompiledTest do
 
   describe "build_metadata/1" do
     test "builds a valid metadata" do
-      config = %RustlerPrecompiled.Config{
-        otp_app: :rustler_precompiled,
-        module: RustlerPrecompilationExample.Native,
-        base_url:
-          "https://github.com/philss/rustler_precompilation_example/releases/download/v0.2.0",
-        version: "0.2.0",
-        crate: "example",
-        targets: @available_targets,
-        variants: %{},
-        nif_versions: @available_nif_versions
-      }
+      config =
+        RustlerPrecompiled.Config.new(
+          otp_app: :rustler_precompiled,
+          module: RustlerPrecompilationExample.Native,
+          base_url:
+            "https://github.com/philss/rustler_precompilation_example/releases/download/v0.2.0",
+          version: "0.2.0",
+          crate: "example",
+          targets: @available_targets,
+          variants: %{},
+          nif_versions: @available_nif_versions,
+          force_build: false
+        )
 
       assert {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
 
@@ -777,16 +793,18 @@ defmodule RustlerPrecompiledTest do
     end
 
     test "returns error when current target is not available" do
-      config = %RustlerPrecompiled.Config{
-        otp_app: :rustler_precompiled,
-        module: RustlerPrecompilationExample.Native,
-        base_url:
-          "https://github.com/philss/rustler_precompilation_example/releases/download/v0.2.0",
-        version: "0.2.0",
-        crate: "example",
-        targets: ["hexagon-unknown-linux-musl"],
-        nif_versions: @available_nif_versions
-      }
+      config =
+        RustlerPrecompiled.Config.new(
+          otp_app: :rustler_precompiled,
+          module: RustlerPrecompilationExample.Native,
+          base_url:
+            "https://github.com/philss/rustler_precompilation_example/releases/download/v0.2.0",
+          version: "0.2.0",
+          crate: "example",
+          targets: ["hexagon-unknown-linux-musl"],
+          nif_versions: @available_nif_versions,
+          force_build: false
+        )
 
       assert {:error, error} = RustlerPrecompiled.build_metadata(config)
       assert error =~ "precompiled NIF is not available for this target: "
@@ -857,16 +875,18 @@ defmodule RustlerPrecompiledTest do
     end
 
     test "builds a valid metadata with a restrict NIF versions list" do
-      config = %RustlerPrecompiled.Config{
-        otp_app: :rustler_precompiled,
-        module: RustlerPrecompilationExample.Native,
-        base_url:
-          "https://github.com/philss/rustler_precompilation_example/releases/download/v0.2.0",
-        version: "0.2.0",
-        crate: "example",
-        targets: @available_targets,
-        nif_versions: ["2.15"]
-      }
+      config =
+        RustlerPrecompiled.Config.new(
+          otp_app: :rustler_precompiled,
+          module: RustlerPrecompilationExample.Native,
+          base_url:
+            "https://github.com/philss/rustler_precompilation_example/releases/download/v0.2.0",
+          version: "0.2.0",
+          crate: "example",
+          targets: @available_targets,
+          nif_versions: ["2.15"],
+          force_build: false
+        )
 
       assert {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
 
@@ -874,22 +894,24 @@ defmodule RustlerPrecompiledTest do
     end
 
     test "builds a valid metadata with specified variants" do
-      config = %RustlerPrecompiled.Config{
-        otp_app: :rustler_precompiled,
-        module: RustlerPrecompilationExample.Native,
-        base_url:
-          "https://github.com/philss/rustler_precompilation_example/releases/download/v0.2.0",
-        version: "0.2.0",
-        crate: "example",
-        targets: @available_targets,
-        variants: %{
-          "x86_64-unknown-linux-gnu" => [
-            old_glibc: fn _config -> true end,
-            legacy_cpus: fn _config -> true end
-          ]
-        },
-        nif_versions: @available_nif_versions
-      }
+      config =
+        RustlerPrecompiled.Config.new(
+          otp_app: :rustler_precompiled,
+          module: RustlerPrecompilationExample.Native,
+          base_url:
+            "https://github.com/philss/rustler_precompilation_example/releases/download/v0.2.0",
+          version: "0.2.0",
+          crate: "example",
+          targets: @available_targets,
+          variants: %{
+            "x86_64-unknown-linux-gnu" => [
+              old_glibc: fn _config -> true end,
+              legacy_cpus: fn _config -> true end
+            ]
+          },
+          nif_versions: @available_nif_versions,
+          force_build: false
+        )
 
       assert {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
 
@@ -903,22 +925,24 @@ defmodule RustlerPrecompiledTest do
     end
 
     test "builds a valid metadata saving the current variant as legacy CPU" do
-      config = %RustlerPrecompiled.Config{
-        otp_app: :rustler_precompiled,
-        module: RustlerPrecompilationExample.Native,
-        base_url:
-          "https://github.com/philss/rustler_precompilation_example/releases/download/v0.2.0",
-        version: "0.2.0",
-        crate: "example",
-        targets: @available_targets,
-        variants: %{
-          "x86_64-unknown-linux-gnu" => [
-            old_glibc: fn _config -> false end,
-            legacy_cpus: fn _config -> true end
-          ]
-        },
-        nif_versions: @available_nif_versions
-      }
+      config =
+        RustlerPrecompiled.Config.new(
+          otp_app: :rustler_precompiled,
+          module: RustlerPrecompilationExample.Native,
+          base_url:
+            "https://github.com/philss/rustler_precompilation_example/releases/download/v0.2.0",
+          version: "0.2.0",
+          crate: "example",
+          targets: @available_targets,
+          variants: %{
+            "x86_64-unknown-linux-gnu" => [
+              old_glibc: fn _config -> false end,
+              legacy_cpus: fn _config -> true end
+            ]
+          },
+          nif_versions: @available_nif_versions,
+          force_build: false
+        )
 
       assert {:ok, metadata} = RustlerPrecompiled.build_metadata(config)
 


### PR DESCRIPTION
The :base_url attribute now accepts static headers or a custom function that returns a URL and headers. This allows us to fetch NIFs from more complicated sources, rather than just public GitHub releases.

#65 