### PR TITLE
added ca cert override via env var

### DIFF
--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -925,13 +925,7 @@ defmodule RustlerPrecompiled do
 
     # https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/inets
     # respects the user provided ca certs via Hex env var
-    cacertfile = System.get_env("HEX_CACERTS_PATH")
-
-    if cacertfile do
-      cacertfile
-    else
-      CAStore.file_path()
-    end
+    cacertfile = System.get_env("HEX_CACERTS_PATH", CAStore.file_path())
 
     http_options = [
       ssl: [

--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -924,12 +924,19 @@ defmodule RustlerPrecompiled do
     end
 
     # https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/inets
-    cacertfile = CAStore.file_path() |> String.to_charlist()
+    # respects the user provided ca certs via Hex env var
+    cacertfile = System.get_env("HEX_CACERTS_PATH")
+
+    if cacertfile do
+      cacertfile
+    else
+      CAStore.file_path()
+    end
 
     http_options = [
       ssl: [
         verify: :verify_peer,
-        cacertfile: cacertfile,
+        cacertfile: cacertfile |> String.to_charlist(),
         # We need to increase depth because the default value is 1.
         # See: https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/ssl
         depth: 3,


### PR DESCRIPTION
Super simple change to override the `:castore` use with the Hex ca store env var when set by a user. Needed by those behind corporate firewalls who typically have to set their own CA certs