### PR TITLE
don't assume File.mkdir_p succeeds when writing metadata.

### DIFF
--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -1056,9 +1056,10 @@ defmodule RustlerPrecompiled do
       :ok
     else
       dir = Path.dirname(metadata_file)
-      :ok = File.mkdir_p(dir)
 
-      File.write(metadata_file, inspect(metadata, limit: :infinity, pretty: true))
+      with :ok <- File.mkdir_p(dir) do
+        File.write(metadata_file, inspect(metadata, limit: :infinity, pretty: true))
+      end
     end
   end
 


### PR DESCRIPTION
This is a minor change which makes working with Nix a little bit easier.

`write_metadata/2` passes a failed file write to its caller, `__using__/2`, which logs it as a warning. This is great, but on Nix the `File.mkdir_p/1` fails before we get there, and currently this causes the whole process to abort.

This PR just forwards any error from `File.mkdir_p/1` to the caller instead of raising a `MatchError`.