### PR TITLE
Add support for NIF version 2.18 (OTP 29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for NIF version `2.18`, which is shipped with Erlang/OTP 29.
+
 ## [0.9.0] - 2026-03-26
 
 ### Added

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -43,6 +43,7 @@ default = ["nif_version_2_15"]
 nif_version_2_15 = ["rustler/nif_version_2_15"]
 nif_version_2_16 = ["rustler/nif_version_2_16"]
 nif_version_2_17 = ["rustler/nif_version_2_17"]
+nif_version_2_18 = ["rustler/nif_version_2_18"]
 ```
 
 In your code, you would use these features - like `nif_version_2_16` - to control how your
@@ -61,6 +62,7 @@ The available NIF versions are the following:
 * `2.15` - for OTP 22 and above.
 * `2.16` - for OTP 24 and above.
 * `2.17` - for OTP 26 and above.
+* `2.18` - for OTP 29 and above.
 
 And the default NIF version activated by Rustler versions is the following:
 

--- a/lib/rustler_precompiled.ex
+++ b/lib/rustler_precompiled.ex
@@ -74,6 +74,7 @@ defmodule RustlerPrecompiled do
       * `2.15` - for OTP 22 and above.
       * `2.16` - for OTP 24 and above.
       * `2.17` - for OTP 26 and above.
+      * `2.18` - for OTP 29 and above.
 
       By default the following NIF versions are configured:
 

--- a/lib/rustler_precompiled/config.ex
+++ b/lib/rustler_precompiled/config.ex
@@ -30,7 +30,7 @@ defmodule RustlerPrecompiled.Config do
     x86_64-unknown-linux-musl
   )
 
-  @available_nif_versions ~w(2.14 2.15 2.16 2.17)
+  @available_nif_versions ~w(2.14 2.15 2.16 2.17 2.18)
   @default_nif_versions ~w(2.15)
 
   def default_targets, do: @default_targets

--- a/test/rustler_precompiled_test.exs
+++ b/test/rustler_precompiled_test.exs
@@ -243,7 +243,7 @@ defmodule RustlerPrecompiledTest do
       }
 
       error_message =
-        "precompiled NIF is not available for this NIF version: \"2.10\".\nThe available NIF versions are:\n - 2.14\n - 2.15\n - 2.16\n - 2.17"
+        "precompiled NIF is not available for this NIF version: \"2.10\".\nThe available NIF versions are:\n - 2.14\n - 2.15\n - 2.16\n - 2.17\n - 2.18"
 
       assert {:error, ^error_message} =
                RustlerPrecompiled.target(config, @available_targets, @available_nif_versions)
@@ -1076,6 +1076,8 @@ defmodule RustlerPrecompiledTest do
                  "example-v0.2.0-nif-2.16-x86_64-pc-windows-msvc.dll.tar.gz",
                  "example-v0.2.0-nif-2.17-x86_64-pc-windows-gnu.dll.tar.gz",
                  "example-v0.2.0-nif-2.17-x86_64-pc-windows-msvc.dll.tar.gz",
+                 "example-v0.2.0-nif-2.18-x86_64-pc-windows-gnu.dll.tar.gz",
+                 "example-v0.2.0-nif-2.18-x86_64-pc-windows-msvc.dll.tar.gz",
                  "libexample-v0.2.0-nif-2.14-aarch64-apple-darwin.so.tar.gz",
                  "libexample-v0.2.0-nif-2.14-aarch64-unknown-linux-gnu.so.tar.gz",
                  "libexample-v0.2.0-nif-2.14-aarch64-unknown-linux-musl.so.tar.gz",
@@ -1115,7 +1117,17 @@ defmodule RustlerPrecompiledTest do
                  "libexample-v0.2.0-nif-2.17-x86_64-unknown-linux-gnu--legacy_cpus.so.tar.gz",
                  "libexample-v0.2.0-nif-2.17-x86_64-unknown-linux-gnu--old_glibc.so.tar.gz",
                  "libexample-v0.2.0-nif-2.17-x86_64-unknown-linux-gnu.so.tar.gz",
-                 "libexample-v0.2.0-nif-2.17-x86_64-unknown-linux-musl.so.tar.gz"
+                 "libexample-v0.2.0-nif-2.17-x86_64-unknown-linux-musl.so.tar.gz",
+                 "libexample-v0.2.0-nif-2.18-aarch64-apple-darwin.so.tar.gz",
+                 "libexample-v0.2.0-nif-2.18-aarch64-unknown-linux-gnu.so.tar.gz",
+                 "libexample-v0.2.0-nif-2.18-aarch64-unknown-linux-musl.so.tar.gz",
+                 "libexample-v0.2.0-nif-2.18-arm-unknown-linux-gnueabihf.so.tar.gz",
+                 "libexample-v0.2.0-nif-2.18-riscv64gc-unknown-linux-gnu.so.tar.gz",
+                 "libexample-v0.2.0-nif-2.18-x86_64-apple-darwin.so.tar.gz",
+                 "libexample-v0.2.0-nif-2.18-x86_64-unknown-linux-gnu--legacy_cpus.so.tar.gz",
+                 "libexample-v0.2.0-nif-2.18-x86_64-unknown-linux-gnu--old_glibc.so.tar.gz",
+                 "libexample-v0.2.0-nif-2.18-x86_64-unknown-linux-gnu.so.tar.gz",
+                 "libexample-v0.2.0-nif-2.18-x86_64-unknown-linux-musl.so.tar.gz"
                ]
                |> Enum.map(fn file_name -> "#{base_url}/#{file_name}" end)
     end


### PR DESCRIPTION
## Summary

Adds support for NIF version `2.18`, which ships with Erlang/OTP 29.

OTP 29's `erl_nif.h` bumped the NIF interface to `2.18` (`ERL_NIF_MAJOR_VERSION 2` / `ERL_NIF_MINOR_VERSION 18`); OTP 26–28 remained on `2.17`. Without `2.18` in the available list, projects upgrading to a rustler that exposes the `nif_version_2_18` feature can't publish or select 2.18 precompiled artifacts.

The forward-compatibility resolver (`find_compatible_nif_version/2`) already handles running on a newer NIF than what's published, so no logic change was needed — only adding `2.18` to the allow-list.

The default NIF version is unchanged (`2.15`), so existing consumers are unaffected — `2.18` is opt-in via `nif_versions:`.